### PR TITLE
Add rule to check for hard-coded/unlocalizable string

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,11 @@ workflows:
   test-all-node-versions:
     jobs:
       - test:
-          docker_image: circleci/node:14-browsers
+          docker_image: cimg/node:14.21-browsers
       - test:
-          docker_image: circleci/node:16-browsers
+          docker_image: cimg/node:16.20-browsers
+      - test:
+          docker_image: cimg/node:18.9-browsers
+      - test:
+          docker_image: cimg/node:20.9-browsers
       - test

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ limitations under the License.
 - added Typescript and TSX parser
 - changed existing JavaScript, JSX, Flow, FlowJSX parsers to all produce Babel-style AST
 - added rule to ban usage of FormattedCompMessage
+- added rule to check for hard-coded strings and attributes in React code
 
 ### v1.2.0
 

--- a/docs/no-hard-coded-strings.md
+++ b/docs/no-hard-coded-strings.md
@@ -1,0 +1,190 @@
+# no-hard-coded-strings
+
+This rule checks for hard-coded strings in your code, which are, of course, not localizable.
+
+## JSX/TSX
+
+This rule checks your jsx/tsx code for text elements in the middle of your components.
+
+Example:
+
+```jsx
+render() {
+    return (
+        <>
+            <Button className="some-button" type="button">
+                Click me
+            </Button>
+        </>
+    );
+}
+```
+
+In this example, the text "Click me" will be flagged as hard-coded text. There are two
+methods for resolving this problem, depending on the style of your project:
+
+Method 1: (leaving the text in the file)
+
+```jsx
+render() {
+    return (
+        <>
+            <Button className="some-button" type="button">
+                <FormattedMessage
+                    id="unique-id"
+                    defaultMessage="Click me"
+                    description="Notes for the translator to understand what this message is about and how it is used in the UI"
+                />
+            </Button>
+        </>
+    );
+}
+```
+
+Method 2: (extracting the text elsewhere)
+
+```jsx
+messages.js:
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+    unique_id: {
+        id: "unique-id",
+        defaultMessage: "Click me",
+        description: "Notes for the translator to understand what this message is about and how it is used in the UI"
+    }
+});
+
+in your original source file:
+render() {
+    return (
+        <>
+            <Button className="some-button" type="button">
+                <FormattedMessage {...messages.unique_id} />
+            </Button>
+        </>
+    );
+}
+```
+
+The rule and the fixes above can also work with JS+Flow or Typescript.
+
+## Imperative React
+
+If you are using imperative React in your Javascript, this rule will still work. Example:
+
+```js
+render() {
+    return React.createElement(
+        React.Fragment,
+        {},
+        React.createElement(Button, { className: "some-button", type: "button" }, "Click me")
+    );
+}
+```
+
+In this example, the text "Click me" will be flagged as hard-coded text, just like in the first example. The
+fix is to use imperative React API `intl.formatMessage` to get the translation:
+
+```js
+render() {
+    return React.createElement(
+        React.Fragment,
+        {},
+        React.createElement(
+            Button, 
+            { className: "some-button", type: "button" }, 
+            intl.formatMessage(messages.unique_id)
+        )
+    );
+}
+```
+
+## HTML Attributes
+
+Some HTML attributes on some HTML tags are commonly shown in the UI and should therefore be
+translated. This rule will find those attribute values and flag them. Example:
+
+```jsx
+render() {
+    return (
+        <>
+            <input type="button" placeholder="Your Name" />
+        </>
+    );
+}
+```
+
+In the above example, the value of the `placeholder` attribute is supposed to be localized,
+but is unfortunately hard-coded. This rule will flag that.
+
+The fix is to use `intl.formatMessage` to get the translation:
+
+```jsx
+render() {
+    return (
+        <>
+            <input type="button" placeholder={intl.formatMessage(unique_id)} />
+        </>
+    );
+}
+```
+
+For some attributes, such as "title" and all of the "aria-*" attributes, the values will
+be flagged for all components and HTML tags.
+
+### Table of Localizable Attributes
+
+| tag | attribute |
+| ---- | ----- |
+| area | alt |
+| img | alt |
+| input | alt |
+| input | placeholder |
+| optgroup | label |
+| option | label |
+| textarea | placeholder |
+| track | label |
+| * | title |
+| * | aria-braillelabel |
+| * | aria-brailleroledescription |
+| * | aria-description |
+| * | aria-label |
+| * | aria-placeholder |
+| * | aria-roledescription |
+| * | aria-rowindextext |
+| * | aria-valuetext |
+
+"*" in the above table means "all components and HTML tags"
+
+### Attributes in Imperative React
+
+This rule will also check the attributes in imperative React. Example:
+
+```js
+render() {
+    return React.createElement(
+        React.Fragment,
+        {},
+        React.createElement(input, { placeholder: "Your name", type: "button" })
+    );
+}
+```
+
+The rule will flag the text "Your name" as hard-coded. The fix is to use `intl.formatMessage`:
+
+```jsx
+render() {
+    return React.createElement(
+        React.Fragment,
+        {},
+        React.createElement(input, { placeholder: intl.formatMessage(messages.myMessage), type: "button" })
+    );
+}
+```
+
+## See also
+
+- [react-intl rich text formatting documentation](https://formatjs.io/docs/react-intl/components/#rich-text-formatting)
+- [react-intl imperative API `intl.formatMessage`](https://formatjs.io/docs/react-intl/api/#formatmessage)
+- [rich text formatting changes in react-intl v2 -> v3 upgrade guide](https://formatjs.io/docs/react-intl/upgrade-guide-3x/#enhanced-formattedmessage--formatmessage-rich-text-formatting)

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "i18nlint-common": "^2.2.1",
         "ilib-istring": "^1.0.1",
         "ilib-locale": "^1.2.2",
-        "ilib-tools-common": "^1.8.1",
+        "ilib-tools-common": "file:../ilib-tools-common/ilib-tools-common-1.9.1.tgz",
         "jsonpath": "^1.1.1",
         "regenerator-runtime": "^0.14.0"
     }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "doc:html": "jsdoc -c jsdoc.json"
     },
     "devDependencies": {
-        "@babel/types": "^7.23.5",
+        "@babel/types": "^7.23.6",
         "docdash": "^2.0.2",
         "jest": "^29.7.0",
         "jsdoc": "^4.0.2",
@@ -37,14 +37,14 @@
         "npm-run-all": "^4.1.5"
     },
     "dependencies": {
-        "@babel/parser": "^7.23.5",
-        "@babel/traverse": "^7.23.5",
+        "@babel/parser": "^7.23.6",
+        "@babel/traverse": "^7.23.6",
         "@formatjs/intl": "^2.9.9",
         "i18nlint-common": "^2.2.1",
-        "ilib-istring": "^1.0.1",
+        "ilib-istring": "^1.1.0",
         "ilib-locale": "^1.2.2",
-        "ilib-tools-common": "file:../ilib-tools-common/ilib-tools-common-1.9.1.tgz",
+        "ilib-tools-common": "^1.9.1",
         "jsonpath": "^1.1.1",
-        "regenerator-runtime": "^0.14.0"
+        "regenerator-runtime": "^0.14.1"
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ import PropertiesParser from "./parsers/PropertiesParser.js";
 import FlowParser from "./parsers/FlowParser.js";
 import TSXParser from "./parsers/TSXParser.js";
 import BanFormattedCompMessage from "./rules/BanFormattedCompMessage.js";
+import NoHardCodedStrings from "./rules/NoHardCodedStrings.js";
 // import FormatjsPlurals from './rules/FormatjsPlurals.js';
 
 class ReactPlugin extends Plugin {
@@ -53,7 +54,8 @@ class ReactPlugin extends Plugin {
         //console.log("ReactPlugin.getRules() called");
         return [
             // FormatjsPlurals // not ready for prime time yet
-            BanFormattedCompMessage
+            BanFormattedCompMessage,
+            NoHardCodedStrings
         ];
     }
 
@@ -62,7 +64,8 @@ class ReactPlugin extends Plugin {
         return {
             react: {
                 // "source-formatjs-plurals": true, // not ready for prime time yet
-                "ban-formattedcompmessage": true
+                "ban-formattedcompmessage": true,
+                "no-hard-coded-strings": true
             }
         };
     }

--- a/src/rules/NoHardCodedStrings.js
+++ b/src/rules/NoHardCodedStrings.js
@@ -78,8 +78,8 @@ class NoHardCodedStrings extends Rule {
             CallExpression(path) {
                 const callee = path.node.callee;
                 // only check arguments to the calls to React.createElement()
-                if (callee?.object?.name === "React" && 
-                        callee.property?.name === "createElement" && 
+                if (callee?.object?.name === "React" &&
+                        callee.property?.name === "createElement" &&
                         path.node?.arguments.length > 0) {
                     const args = path.node.arguments;
                     if (args[0].type === "Identifier") {

--- a/src/rules/NoHardCodedStrings.js
+++ b/src/rules/NoHardCodedStrings.js
@@ -1,0 +1,127 @@
+/*
+ * NoHardCodedStrings.js - check for hard-coded (and therefore unlocalizable) strings
+ *
+ * Copyright © 2023 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Result, Rule } from "i18nlint-common";
+import { Utils } from 'ilib-common';
+import { localizableAttributes } from 'ilib-tools-common';
+
+import _traverse from "@babel/traverse";
+const traverse = _traverse.default;
+import _generate from "@babel/generator";
+const generate = _generate.default;
+
+function isAttributeLocalizable(tagName, attributeName) {
+    return (typeof(localizableAttributes[tagName]) !== 'undefined' &&
+        localizableAttributes[tagName][attributeName]) ||
+        localizableAttributes["*"][attributeName];
+}
+
+// these ones are supposed to have text in them
+const skipComponents = new Set([
+    "FormattedCompMessage",
+    "FormattedMessage"
+]);
+
+// type imports
+/** @typedef {import("i18nlint-common").IntermediateRepresentation} IntermediateRepresentation */
+/** @typedef {import("@babel/parser").ParseResult<import("@babel/types").File>} ParseResult */
+
+class NoHardCodedStrings extends Rule {
+    /** @readonly */
+    name = "no-hard-coded-strings";
+
+    /** @readonly */
+    description = "Disallow hard-coded strings in between components and in certain HTML attributes";
+
+    /** @readonly */
+    link =
+        "https://github.com/ilib-js/ilib-lint-react/blob/main/docs/no-hard-coded-strings.md";
+
+    /** @readonly */
+    type = "babel-ast";
+
+    /** @override */
+    match({ ir }) {
+        if (ir.type !== this.type) {
+            throw new Error(`Unexpected representation type!`);
+        }
+
+        const tree = ir.getRepresentation();
+        const results = [];
+
+        traverse(tree, {
+            JSXElement(path) {
+                const nameNode = path.node?.openingElement.name;
+                if (nameNode?.type === "JSXIdentifier" && skipComponents.has(nameNode?.name)) {
+                    // skip components that should have text in them
+                    path.skip();
+                }
+            },
+
+            JSXOpeningElement(path) {
+                const nameNode = path.node.name;
+                if (nameNode.type === "JSXIdentifier") {
+                    const tagName = nameNode.name;
+                    path.node.attributes.forEach(attribute => {
+                        if (attribute.type === "JSXAttribute" &&
+                                attribute.name?.type === "JSXIdentifier" &&
+                                isAttributeLocalizable(tagName, attribute.name.name) &&
+                                attribute.value?.type === "StringLiteral") {
+                            results.push({
+                                pathName: ir.filePath,
+                                severity: "error",
+                                description: `Found unlocalizable hard-coded attribute value. Use intl.formatMessage() instead.`,
+                                id: undefined,
+                                lineNumber: attribute.loc.start.line,
+                                charNumber: attribute.loc.start.column,
+                                endLineNumber: attribute.loc.end.line,
+                                endCharNumber: attribute.loc.end.column,
+                                // @TODO make a real highlight once IR contains raw content of the linted source file
+                                highlight: `<e0>${generate(attribute).code}</e0>`
+                            });
+                        }
+                    });
+                }
+            },
+
+            JSXText(path) {
+                const text = path.node;
+                // don't report on all whitespace strings!
+                if (text?.value.trim() !== "") {
+                    results.push({
+                        pathName: ir.filePath,
+                        severity: "error",
+                        description: `Found unlocalizable hard-coded string. Use a FormattedMessage component instead.`,
+                        id: undefined,
+                        lineNumber: text.loc.start.line,
+                        charNumber: text.loc.start.column,
+                        endLineNumber: text.loc.end.line,
+                        endCharNumber: text.loc.end.column,
+                        // @TODO make a real highlight once IR contains raw content of the linted source file
+                        highlight: `<e0>${text.value.trim()}</e0>`
+                    });
+                }
+            }
+        });
+
+        return results.map(result => new Result({...result, rule: this}));
+    }
+}
+
+export default NoHardCodedStrings;

--- a/test/ReactPlugin.test.js
+++ b/test/ReactPlugin.test.js
@@ -47,7 +47,7 @@ describe("testReactPlugin", () => {
 
         const rules = jp.getRules();
         expect(rules).toBeTruthy();
-        expect(rules.length).toBe(1);
+        expect(rules.length).toBe(2);
     });
 
     test("ReactPluginGetFormatters", () => {
@@ -70,6 +70,6 @@ describe("testReactPlugin", () => {
         const sets = jp.getRuleSets();
 
         expect(sets.react).toBeTruthy();
-        expect(Object.keys(sets.react).length).toBe(1);
+        expect(Object.keys(sets.react).length).toBe(2);
     });
 });

--- a/test/rules/BanFormattedCompMessage.test.js
+++ b/test/rules/BanFormattedCompMessage.test.js
@@ -107,7 +107,7 @@ describe("BanFormattedCompMessage", () => {
                                     description="Some message description"
                                     defaultMessage="Some message with <Link>link text</Link> and more text."
                                     values={{
-                                        Link: (chunks) => <Link href="example.com">chunks</Link>,
+                                        Link: (chunks) => <Link href="example.com">{...chunks}</Link>,
                                     }}
                                 />
                                 <Button className="some-button" type="button">
@@ -207,7 +207,7 @@ describe("BanFormattedCompMessage", () => {
                                     description="Some message description"
                                     defaultMessage="Some message with <Link>link text</Link> and more text."
                                     values={{
-                                        Link: (chunks) => <Link href="example.com">chunks</Link>,
+                                        Link: (chunks) => <Link href="example.com">{...chunks}</Link>,
                                     }}
                                 />
                                 <Button className="some-button" type="button">

--- a/test/rules/NoHardCodedStrings.test.js
+++ b/test/rules/NoHardCodedStrings.test.js
@@ -43,7 +43,7 @@ describe("NoHardCodedStrings", () => {
                 // @flow
                 import * as React from "react";
                 import { Button, Link, FormattedCompMessage } from "components";
-                
+
                 export class CustomComponent extends React.Component {
                     render() {
                         return (
@@ -178,7 +178,7 @@ describe("NoHardCodedStrings", () => {
                 // @flow
                 import * as React from "react";
                 import { Button, Link, FormattedCompMessage } from "components";
-                
+
                 export class CustomComponent extends React.Component {
                     render() {
                         return (
@@ -220,7 +220,7 @@ describe("NoHardCodedStrings", () => {
                 // @flow
                 import * as React from "react";
                 import { Button, Link, FormattedCompMessage } from "components";
-                
+
                 export class CustomComponent extends React.Component {
                     render() {
                         return (
@@ -256,7 +256,7 @@ describe("NoHardCodedStrings", () => {
                 `
                 import * as React from "react";
                 import { Button, Link, FormattedCompMessage } from "components";
-                
+
                 export class CustomComponent extends React.Component {
                     render() {
                         return (
@@ -387,7 +387,7 @@ describe("NoHardCodedStrings", () => {
                 `
                 import * as React from "react";
                 import { Button, Link, FormattedCompMessage } from "components";
-                
+
                 export class CustomComponent extends React.Component {
                     render() {
                         return (
@@ -428,7 +428,7 @@ describe("NoHardCodedStrings", () => {
                 `
                 import * as React from "react";
                 import { Button, Link, FormattedCompMessage } from "components";
-                
+
                 export class CustomComponent extends React.Component {
                     render() {
                         return (

--- a/test/rules/NoHardCodedStrings.test.js
+++ b/test/rules/NoHardCodedStrings.test.js
@@ -240,4 +240,428 @@ describe("NoHardCodedStrings", () => {
             expect(result.length).toEqual(0);
         });
     });
+
+    describe("JSX", () => {
+        const getJsxIr = (filePath, content) => {
+            const parser = new JSXParser();
+            parser.data = trimIndent(content);
+            parser.path = filePath;
+            const [ir] = parser.parse();
+            return ir;
+        };
+
+        test("hard coded string in JSX", () => {
+            const ir = getJsxIr(
+                "x/y.js",
+                `
+                import * as React from "react";
+                import { Button, Link, FormattedCompMessage } from "components";
+                
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return (
+                            <>
+                                <Button className="some-button" type="button">
+                                    Click me
+                                </Button>
+                            </>
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoHardCodedStrings();
+
+            const result = rule.match({ ir });
+
+            const expected = [
+                new Result({
+                    severity: "error",
+                    description:
+                        "Found unlocalizable hard-coded string. Use a FormattedMessage component instead.",
+                    pathName: "x/y.js",
+                    rule,
+                    highlight: `<e0>Click me</e0>`,
+                    lineNumber: 9,
+                    charNumber: 62,
+                    endLineNumber: 11,
+                    endCharNumber: 16,
+                })
+            ];
+
+            expect(result).toStrictEqual(expected);
+        });
+
+        test("no hard-coded strings used in file", () => {
+            const ir = getJsxIr(
+                "x/y.js",
+                `
+                import * as React from "react";
+                import { Button, Link, FormattedMessage } from "components";
+
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return (
+                            <>
+                                <Button title={messages.myString}>
+                                </Button>
+                            </>
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoHardCodedStrings();
+
+            const result = rule.match({ ir });
+
+            expect(result.length).toEqual(0);
+        });
+
+        test("skipping hard-coded text inside of a FormattedMessage component", () => {
+            const ir = getJsxIr(
+                "x/y.js",
+                `
+                import * as React from "react";
+                import { Button, Link, FormattedMessage } from "components";
+
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return (
+                            <>
+                                <FormattedMessage
+                                    id="some.id"
+                                    description="Some message description"
+                                    defaultMessage="Some message with <Link>link text</Link> and more text."
+                                    values={{
+                                        Link: (chunks) => <Link href="example.com">chunks</Link>,
+                                    }}
+                                />
+                            </>
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoHardCodedStrings();
+
+            const result = rule.match({ ir });
+
+            expect(result.length).toEqual(0);
+        });
+
+        test("skipping hard-coded text inside of a FormattedCompMessage component", () => {
+            const ir = getJsxIr(
+                "x/y.js",
+                `
+                import * as React from "react";
+                import { Button, Link, FormattedMessage } from "components";
+
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return (
+                            <>
+                                <FormattedCompMessage id="some.id" description="Some message description">
+                                    Some message with <Link href="example.com">link text</Link> and more text.
+                                </FormattedCompMessage>
+                            </>
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoHardCodedStrings();
+
+            const result = rule.match({ ir });
+
+            expect(result.length).toEqual(0);
+        });
+
+        test("hard coded string in HTML attribute", () => {
+            const ir = getJsxIr(
+                "x/y.js",
+                `
+                import * as React from "react";
+                import { Button, Link, FormattedCompMessage } from "components";
+                
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return (
+                            <>
+                                <input type="button" placeholder = 'Your name' />
+                            </>
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoHardCodedStrings();
+
+            const result = rule.match({ ir });
+
+            const expected = [
+                new Result({
+                    severity: "error",
+                    description:
+                        "Found unlocalizable hard-coded attribute value. Use intl.formatMessage() instead.",
+                    pathName: "x/y.js",
+                    rule,
+                    highlight: `<e0>placeholder='Your name'</e0>`,
+                    lineNumber: 9,
+                    charNumber: 37,
+                    endLineNumber: 9,
+                    endCharNumber: 62,
+                })
+            ];
+
+            expect(result).toStrictEqual(expected);
+        });
+
+        test("no hard coded string in HTML attribute", () => {
+            const ir = getJsxIr(
+                "x/y.js",
+                `
+                import * as React from "react";
+                import { Button, Link, FormattedCompMessage } from "components";
+                
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return (
+                            <>
+                                <input type="button" placeholder={intl.formatMessage(...messages.myMessage)} />
+                            </>
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoHardCodedStrings();
+
+            const result = rule.match({ ir });
+
+            expect(result.length).toEqual(0);
+        });
+    });
+
+    describe("Flow", () => {
+        const getFlowIr = (filePath, content) => {
+            const parser = new FlowParser();
+            parser.data = trimIndent(content);
+            parser.path = filePath;
+            const [ir] = parser.parse();
+            return ir;
+        };
+
+        test("hard coded string in Flow", () => {
+            const ir = getFlowIr(
+                "x/y.js",
+                `
+                // @flow
+                import * as React from "react";
+                import { Button, Link, FormattedCompMessage } from "components";
+
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return React.createElement(
+                            React.Fragment,
+                            {},
+                            React.createElement(Button, { className: "some-button", type: "button" }, "Click me")
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoHardCodedStrings();
+
+            const result = rule.match({ ir });
+
+            const expected = [
+                new Result({
+                    severity: "error",
+                    description:
+                        "Found unlocalizable hard-coded string. Use intl.formatMessage() instead.",
+                    pathName: "x/y.js",
+                    rule,
+                    highlight: `<e0>Click me</e0>`,
+                    lineNumber: 11,
+                    charNumber: 86,
+                    endLineNumber: 11,
+                    endCharNumber: 96,
+                })
+            ];
+
+            expect(result).toStrictEqual(expected);
+        });
+
+        test("no hard-coded strings used in file", () => {
+            const ir = getFlowIr(
+                "x/y.js",
+                `
+                // @flow
+                import * as React from "react";
+                import { Button, Link, FormattedMessage } from "components";
+
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return React.createElement(
+                            React.Fragment,
+                            {},
+                            React.createElement(span, {
+                                className: "some-class"
+                            })
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoHardCodedStrings();
+
+            const result = rule.match({ ir });
+
+            expect(result.length).toEqual(0);
+        });
+
+        test("skipping hard-coded text inside of a FormattedMessage component", () => {
+            const ir = getFlowIr(
+                "x/y.js",
+                `
+                import * as React from "react";
+                import { Button, Link, FormattedCompMessage } from "components";
+
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return React.createElement(
+                            React.Fragment,
+                            {},
+                            React.createElement(FormattedMessage, {
+                                id: "some.id",
+                                description: "Some message description",
+                                defaultMessage: "Some message with <Link>link text</Link> and more text.",
+                                values: {
+                                    Link: (chunks) => React.createElement(Link, { href: "example.com" }, ...chunks),
+                                },
+                            }),
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoHardCodedStrings();
+
+            const result = rule.match({ ir });
+
+            expect(result.length).toEqual(0);
+        });
+
+        test("skipping hard-coded text inside of a FormattedCompMessage component", () => {
+            const ir = getFlowIr(
+                "x/y.js",
+                `
+                // @flow
+                import * as React from "react";
+                import { Button, Link, FormattedCompMessage } from "components";
+
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return React.createElement(
+                            React.Fragment,
+                            {},
+                            React.createElement(
+                                FormattedCompMessage,
+                                { id: "some.id", description: "Some message description" },
+                                "Some message with ",
+                                React.createElement(Link, { href: "example.com" }, "link text"),
+                                " and more text."
+                            )
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoHardCodedStrings();
+
+            const result = rule.match({ ir });
+
+            expect(result.length).toEqual(0);
+        });
+
+        test("hard coded string in HTML attribute", () => {
+            const ir = getFlowIr(
+                "x/y.js",
+                `
+                // @flow
+                import * as React from "react";
+                import { Button, Link, FormattedCompMessage } from "components";
+
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return React.createElement(
+                            React.Fragment,
+                            {},
+                            React.createElement(input, { placeholder: "Your name", type: "button" })
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoHardCodedStrings();
+
+            const result = rule.match({ ir });
+
+            const expected = [
+                new Result({
+                    severity: "error",
+                    description:
+                        "Found unlocalizable hard-coded attribute value. Use intl.formatMessage() instead.",
+                    pathName: "x/y.js",
+                    rule,
+                    highlight: `<e0>placeholder: "Your name"</e0>`,
+                    lineNumber: 11,
+                    charNumber: 41,
+                    endLineNumber: 11,
+                    endCharNumber: 65,
+                })
+            ];
+
+            expect(result).toStrictEqual(expected);
+        });
+
+        test("no hard coded string in HTML attribute", () => {
+            const ir = getFlowIr(
+                "x/y.js",
+                `
+                // @flow
+                import * as React from "react";
+                import { Button, Link, FormattedCompMessage } from "components";
+
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return React.createElement(
+                            React.Fragment,
+                            {},
+                            React.createElement(input, { placeholder: intl.formatMessage(...messages.myMessage), type: "button" })
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoHardCodedStrings();
+
+            const result = rule.match({ ir });
+
+            expect(result.length).toEqual(0);
+        });
+    });
 });

--- a/test/rules/NoHardCodedStrings.test.js
+++ b/test/rules/NoHardCodedStrings.test.js
@@ -1,0 +1,243 @@
+/*
+ * NoHardCodedStrings.test.js
+ *
+ * Copyright © 2023 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Result } from "i18nlint-common";
+import FlowParser from "../../src/parsers/FlowParser.js";
+import JSParser from "../../src/parsers/JSParser.js";
+import JSXParser from "../../src/parsers/JSXParser.js";
+import NoHardCodedStrings from "../../src/rules/NoHardCodedStrings.js";
+import { trimIndent } from "../utils.js";
+
+/** @typedef {import("i18nlint-common").IntermediateRepresentation} IntermediateRepresentation */
+
+describe("NoHardCodedStrings", () => {
+    describe("Flow JSX", () => {
+        const getFlowJsxIr = (filePath, content) => {
+            const parser = new FlowParser();
+            parser.data = trimIndent(content);
+            parser.path = filePath;
+            const [ir] = parser.parse();
+            return ir;
+        };
+
+        test("hard coded string in Flow JSX", () => {
+            const ir = getFlowJsxIr(
+                "x/y.js",
+                `
+                // @flow
+                import * as React from "react";
+                import { Button, Link, FormattedCompMessage } from "components";
+                
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return (
+                            <>
+                                <Button className="some-button" type="button">
+                                    Click me
+                                </Button>
+                            </>
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoHardCodedStrings();
+
+            const result = rule.match({ ir });
+
+            const expected = [
+                new Result({
+                    severity: "error",
+                    description:
+                        "Found unlocalizable hard-coded string. Use a FormattedMessage component instead.",
+                    pathName: "x/y.js",
+                    rule,
+                    highlight: `<e0>Click me</e0>`,
+                    lineNumber: 10,
+                    charNumber: 62,
+                    endLineNumber: 12,
+                    endCharNumber: 16,
+                })
+            ];
+
+            expect(result).toStrictEqual(expected);
+        });
+
+        test("no hard-coded strings used in file", () => {
+            const ir = getFlowJsxIr(
+                "x/y.js",
+                `
+                // @flow
+                import * as React from "react";
+                import { Button, Link, FormattedMessage } from "components";
+
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return (
+                            <>
+                                <Button title={messages.myString}>
+                                </Button>
+                            </>
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoHardCodedStrings();
+
+            const result = rule.match({ ir });
+
+            expect(result.length).toEqual(0);
+        });
+
+        test("skipping hard-coded text inside of a FormattedMessage component", () => {
+            const ir = getFlowJsxIr(
+                "x/y.js",
+                `
+                // @flow
+                import * as React from "react";
+                import { Button, Link, FormattedMessage } from "components";
+
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return (
+                            <>
+                                <FormattedMessage
+                                    id="some.id"
+                                    description="Some message description"
+                                    defaultMessage="Some message with <Link>link text</Link> and more text."
+                                    values={{
+                                        Link: (chunks) => <Link href="example.com">chunks</Link>,
+                                    }}
+                                />
+                            </>
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoHardCodedStrings();
+
+            const result = rule.match({ ir });
+
+            expect(result.length).toEqual(0);
+        });
+
+        test("skipping hard-coded text inside of a FormattedCompMessage component", () => {
+            const ir = getFlowJsxIr(
+                "x/y.js",
+                `
+                // @flow
+                import * as React from "react";
+                import { Button, Link, FormattedMessage } from "components";
+
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return (
+                            <>
+                                <FormattedCompMessage id="some.id" description="Some message description">
+                                    Some message with <Link href="example.com">link text</Link> and more text.
+                                </FormattedCompMessage>
+                            </>
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoHardCodedStrings();
+
+            const result = rule.match({ ir });
+
+            expect(result.length).toEqual(0);
+        });
+
+        test("hard coded string in HTML attribute", () => {
+            const ir = getFlowJsxIr(
+                "x/y.js",
+                `
+                // @flow
+                import * as React from "react";
+                import { Button, Link, FormattedCompMessage } from "components";
+                
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return (
+                            <>
+                                <input type="button" placeholder = 'Your name' />
+                            </>
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoHardCodedStrings();
+
+            const result = rule.match({ ir });
+
+            const expected = [
+                new Result({
+                    severity: "error",
+                    description:
+                        "Found unlocalizable hard-coded attribute value. Use intl.formatMessage() instead.",
+                    pathName: "x/y.js",
+                    rule,
+                    highlight: `<e0>placeholder='Your name'</e0>`,
+                    lineNumber: 10,
+                    charNumber: 37,
+                    endLineNumber: 10,
+                    endCharNumber: 62,
+                })
+            ];
+
+            expect(result).toStrictEqual(expected);
+        });
+
+        test("no hard coded string in HTML attribute", () => {
+            const ir = getFlowJsxIr(
+                "x/y.js",
+                `
+                // @flow
+                import * as React from "react";
+                import { Button, Link, FormattedCompMessage } from "components";
+                
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return (
+                            <>
+                                <input type="button" placeholder={intl.formatMessage(...messages.myMessage)} />
+                            </>
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoHardCodedStrings();
+
+            const result = rule.match({ ir });
+
+            expect(result.length).toEqual(0);
+        });
+    });
+});

--- a/test/rules/NoHardCodedStrings.test.js
+++ b/test/rules/NoHardCodedStrings.test.js
@@ -125,7 +125,7 @@ describe("NoHardCodedStrings", () => {
                                     description="Some message description"
                                     defaultMessage="Some message with <Link>link text</Link> and more text."
                                     values={{
-                                        Link: (chunks) => <Link href="example.com">chunks</Link>,
+                                        Link: (chunks) => <Link href="example.com">{...chunks}</Link>,
                                     }}
                                 />
                             </>
@@ -336,7 +336,7 @@ describe("NoHardCodedStrings", () => {
                                     description="Some message description"
                                     defaultMessage="Some message with <Link>link text</Link> and more text."
                                     values={{
-                                        Link: (chunks) => <Link href="example.com">chunks</Link>,
+                                        Link: (chunks) => <Link href="example.com">{...chunks}</Link>,
                                     }}
                                 />
                             </>

--- a/test/rules/NoHardCodedStrings.test.js
+++ b/test/rules/NoHardCodedStrings.test.js
@@ -650,7 +650,7 @@ describe("NoHardCodedStrings", () => {
                         return React.createElement(
                             React.Fragment,
                             {},
-                            React.createElement(input, { placeholder: intl.formatMessage(...messages.myMessage), type: "button" })
+                            React.createElement(input, { placeholder: intl.formatMessage(messages.myMessage), type: "button" })
                         );
                     }
                 }


### PR DESCRIPTION
- added new rule no-hard-coded-strings
- checks for strings in JSX, and for some attributes of some HTML tags that are commonly shown in the UI and are commonly translated
- also supports imperative React. (ie. `React.createElement(name, attributes, "some hard coded string")`)

