### PR TITLE
Add rule to check for nested formatted message components or calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.4.0
+
+- added rule to check for usages of FormattedMessage or calls to intl.formatMessage()
+  within the children of another FormattedMessage component. That indicates broken
+  and unlocalizable strings.
+
 ### v1.3.0
 - added Typescript and TSX parser
 - changed existing JavaScript, JSX, Flow, FlowJSX parsers to all produce Babel-style AST

--- a/docs/no-nested-messages.md
+++ b/docs/no-nested-messages.md
@@ -1,0 +1,78 @@
+# no-nested-messages
+
+This rule checks for one way in which strings in your code are not localizable because
+they are broken up in multiple pieces. (Yes, there are multiple ways!)
+
+Translators need entire sentences or fragments in order
+to translate properly. Grammar rules and word ordering are different in other
+languages, so you cannot translate parts of an English sentence separately and glue
+them together in the same order as in English and expect to get the right results
+in all other languages.
+
+Specifically, this rule checks that the code does not use a `FormattedMessage`
+component inside of another `FormattedMessage` component. Also, it checks for calls
+to `intl.formatMessage()` within a `FormattedMessage` component which is the
+imperative programming version of the same thing.
+
+Example of incorrect usage:
+
+```javascript
+export class CustomComponent extends React.Component {
+    render() {
+        return (
+            <>
+                <FormattedMessage
+                    id="my.unique.id"
+                    defaultMessage="You agree to the {termsAndConditionsLink} by using this software."
+                    description="Part of the legal notices to the user at the bottom of the page"
+                    values={{
+                        termsAndConditionsLink:
+                            <a href="terms.html">
+                                <FormattedMessage
+                                    id="terms.and.conditions"
+                                    defaultMessage="terms and conditions"
+                                    description="content of the link that points at the terms and conditions page"
+                                />
+                            </a>
+                    }}
+                />
+            </>
+        );
+    }
+}
+```
+
+In the above example, the translation of the phrase "terms and conditions" is substituted
+in to the outer string. However, the translator that receives the outer string in their
+work queue will be confused as to how to translate the word "the" right before the
+substitution parameter. Is the item mentioned in the parameter masculine or feminine?
+Is it plural or singular? Is it in accusative or dative case? The translator cannot know
+because the second phrase appears in a different point in their work queue or may even
+be assigned to a different translator. The translator cannot assume the two strings are
+linked together, because one or the other string may be shared with another usage of
+the same string in a different context.
+
+The solution is to use rich text formatting feature of react-intl instead, like this:
+
+```javascript
+export class CustomComponent extends React.Component {
+    render() {
+        return (
+            <>
+                <FormattedMessage
+                    id="my.unique.id"
+                    defaultMessage="You agree to the <a>terms and conditions</a> by using this software."
+                    description="Part of the legal notices to the user at the bottom of the page"
+                    values={{
+                        a: (chunks) => <a href="terms.html">{chunks}</a>
+                    }}
+                />
+            </>
+        );
+    }
+}
+```
+
+This allows the translator to see the whole string and translate all its parts
+correctly in context, and even to re-arrange the parts as needed by the grammar of the
+target language. This results in a much better translation across all languages.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint-react",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "main": "./src/index.js",
     "type": "module",
     "exports": {

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ import FlowParser from "./parsers/FlowParser.js";
 import TSXParser from "./parsers/TSXParser.js";
 import BanFormattedCompMessage from "./rules/BanFormattedCompMessage.js";
 import NoHardCodedStrings from "./rules/NoHardCodedStrings.js";
+import NoNestedMessages from "./rules/NoNestedMessages.js";
 // import FormatjsPlurals from './rules/FormatjsPlurals.js';
 
 class ReactPlugin extends Plugin {
@@ -55,7 +56,8 @@ class ReactPlugin extends Plugin {
         return [
             // FormatjsPlurals // not ready for prime time yet
             BanFormattedCompMessage,
-            NoHardCodedStrings
+            NoHardCodedStrings,
+            NoNestedMessages
         ];
     }
 
@@ -65,7 +67,8 @@ class ReactPlugin extends Plugin {
             react: {
                 // "source-formatjs-plurals": true, // not ready for prime time yet
                 "ban-formattedcompmessage": true,
-                "no-hard-coded-strings": true
+                "no-hard-coded-strings": true,
+                "no-nested-messages": true
             }
         };
     }

--- a/src/parsers/TSXParser.js
+++ b/src/parsers/TSXParser.js
@@ -35,24 +35,36 @@ class TSXParser extends Parser {
     /** @readonly */
     type = "babel-ast";
 
+    /**
+     * Construct a new plugin.
+     * @constructor
+     */
+    constructor(options = {}) {
+        super(options);
+        this.filePath = options.filePath;
+    }
+
+    /**
+     * @private
+     */
+    parseString(content, path) {
+        return new IntermediateRepresentation({
+            type: this.type,
+            ir: BabelParser.parse(content, {
+                plugins: ["typescript", "jsx"],
+                sourceType: "unambiguous"
+            }),
+            filePath: path
+        });
+    }
+
     /** @override */
     parse() {
         if (!this.filePath) {
             throw new Error(`Cannot parse because filePath is not set`);
         }
         const content = fs.readFileSync(this.filePath, "utf-8");
-        const parsed = BabelParser.parse(content, {
-            plugins: ["typescript", "jsx"],
-            sourceType: "unambiguous"
-        });
-
-        return [
-            new IntermediateRepresentation({
-                type: this.type,
-                filePath: this.filePath,
-                ir: parsed
-            })
-        ];
+        return [this.parseString(content, this.filePath)];
     }
 }
 

--- a/src/rules/NoNestedMessages.js
+++ b/src/rules/NoNestedMessages.js
@@ -57,7 +57,7 @@ class NoNestedMessages extends Rule {
             // for Flow/imperative React
             CallExpression(path) {
                 const callee = path.node.callee;
-                // only check arguments to the calls to React.createElement()
+                // only check the parents of calls to intl.formatMessage()
                 if (callee?.object?.name === "intl" &&
                         callee.property?.name === "formatMessage" &&
                         path.node?.arguments.length > 0) {

--- a/src/rules/NoNestedMessages.js
+++ b/src/rules/NoNestedMessages.js
@@ -58,59 +58,25 @@ class NoNestedMessages extends Rule {
             CallExpression(path) {
                 const callee = path.node.callee;
                 // only check arguments to the calls to React.createElement()
-                if (callee?.object?.name === "React" &&
-                        callee.property?.name === "createElement" &&
+                if (callee?.object?.name === "intl" &&
+                        callee.property?.name === "formatMessage" &&
                         path.node?.arguments.length > 0) {
-                    const args = path.node.arguments;
-                    if (args[0].type === "Identifier") {
-                        const name = args[0].name;
-
-                        if (skipComponents.has(name)) {
-                            // skip components that are allowed to have text in them
-                            path.skip();
-                            return;
-                        }
-
-                        args.shift();
-
-                        const attributes = args[0];
-                        if (attributes.type === "ObjectExpression") {
-                            attributes.properties.forEach(attribute => {
-                                if (isAttributeLocalizable(name, attribute.key.name) &&
-                                        attribute.value.type === "StringLiteral") {
-                                    results.push({
-                                        pathName: ir.filePath,
-                                        severity: "error",
-                                        description: `Found unlocalizable hard-coded attribute value. Use intl.formatMessage() instead.`,
-                                        id: undefined,
-                                        lineNumber: attribute.loc.start.line,
-                                        charNumber: attribute.loc.start.column,
-                                        endLineNumber: attribute.loc.end.line,
-                                        endCharNumber: attribute.loc.end.column,
-                                        // @TODO make a real highlight once IR contains raw content of the linted source file
-                                        highlight: `<e0>${generate(attribute).code}</e0>`
-                                    });
-                                }
-                            });
-                        }
-
-                        args.shift();
-
-                        args.forEach(argument => {
-                            if (argument.type === "StringLiteral") {
-                                results.push({
-                                    pathName: ir.filePath,
-                                    severity: "error",
-                                    description: `Found unlocalizable hard-coded string. Use intl.formatMessage() instead.`,
-                                    id: undefined,
-                                    lineNumber: argument.loc.start.line,
-                                    charNumber: argument.loc.start.column,
-                                    endLineNumber: argument.loc.end.line,
-                                    endCharNumber: argument.loc.end.column,
-                                    // @TODO make a real highlight once IR contains raw content of the linted source file
-                                    highlight: `<e0>${argument.value.trim()}</e0>`
-                                });
-                            }
+                    const parent = path.findParent(ancestor => {
+                        return (ancestor.node.type === "JSXOpeningElement" &&
+                                ancestor.node.name?.name === "FormattedMessage");
+                    });
+                    if (parent) {
+                        results.push({
+                            pathName: ir.filePath,
+                            severity: "error",
+                            description: `Found a call to intl.formatMessage() inside of a FormattedMessage component. This indicates a broken string.`,
+                            id: undefined,
+                            lineNumber: path.node.loc.start.line,
+                            charNumber: path.node.loc.start.column,
+                            endLineNumber: path.node.loc.end.line,
+                            endCharNumber: path.node.loc.end.column,
+                            // @TODO make a real highlight once IR contains raw content of the linted source file
+                            highlight: `<e0>${generate(path.node).code}</e0>`
                         });
                     }
                 }

--- a/src/rules/NoNestedMessages.js
+++ b/src/rules/NoNestedMessages.js
@@ -1,0 +1,150 @@
+/*
+ * NoNestedMessages.js - check for FormatMessage instances nested inside
+ * each other
+ *
+ * Copyright © 2023 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Result, Rule } from "i18nlint-common";
+import { localizableAttributes } from 'ilib-tools-common';
+
+import _traverse from "@babel/traverse";
+const traverse = _traverse.default;
+import _generate from "@babel/generator";
+const generate = _generate.default;
+
+// type imports
+/** @typedef {import("i18nlint-common").IntermediateRepresentation} IntermediateRepresentation */
+/** @typedef {import("@babel/parser").ParseResult<import("@babel/types").File>} ParseResult */
+
+class NoNestedMessages extends Rule {
+    /** @readonly */
+    name = "no-nested-messages";
+
+    /** @readonly */
+    description = "Disallow use of one FormattedMessage component instance inside of another";
+
+    /** @readonly */
+    link =
+        "https://github.com/ilib-js/ilib-lint-react/blob/main/docs/no-nested-messages.md";
+
+    /** @readonly */
+    type = "babel-ast";
+
+    /** @override */
+    match({ ir }) {
+        if (ir.type !== this.type) {
+            throw new Error(`Unexpected representation type!`);
+        }
+
+        const tree = ir.getRepresentation();
+        const results = [];
+
+        traverse(tree, {
+            // for Flow/imperative React
+            CallExpression(path) {
+                const callee = path.node.callee;
+                // only check arguments to the calls to React.createElement()
+                if (callee?.object?.name === "React" &&
+                        callee.property?.name === "createElement" &&
+                        path.node?.arguments.length > 0) {
+                    const args = path.node.arguments;
+                    if (args[0].type === "Identifier") {
+                        const name = args[0].name;
+
+                        if (skipComponents.has(name)) {
+                            // skip components that are allowed to have text in them
+                            path.skip();
+                            return;
+                        }
+
+                        args.shift();
+
+                        const attributes = args[0];
+                        if (attributes.type === "ObjectExpression") {
+                            attributes.properties.forEach(attribute => {
+                                if (isAttributeLocalizable(name, attribute.key.name) &&
+                                        attribute.value.type === "StringLiteral") {
+                                    results.push({
+                                        pathName: ir.filePath,
+                                        severity: "error",
+                                        description: `Found unlocalizable hard-coded attribute value. Use intl.formatMessage() instead.`,
+                                        id: undefined,
+                                        lineNumber: attribute.loc.start.line,
+                                        charNumber: attribute.loc.start.column,
+                                        endLineNumber: attribute.loc.end.line,
+                                        endCharNumber: attribute.loc.end.column,
+                                        // @TODO make a real highlight once IR contains raw content of the linted source file
+                                        highlight: `<e0>${generate(attribute).code}</e0>`
+                                    });
+                                }
+                            });
+                        }
+
+                        args.shift();
+
+                        args.forEach(argument => {
+                            if (argument.type === "StringLiteral") {
+                                results.push({
+                                    pathName: ir.filePath,
+                                    severity: "error",
+                                    description: `Found unlocalizable hard-coded string. Use intl.formatMessage() instead.`,
+                                    id: undefined,
+                                    lineNumber: argument.loc.start.line,
+                                    charNumber: argument.loc.start.column,
+                                    endLineNumber: argument.loc.end.line,
+                                    endCharNumber: argument.loc.end.column,
+                                    // @TODO make a real highlight once IR contains raw content of the linted source file
+                                    highlight: `<e0>${argument.value.trim()}</e0>`
+                                });
+                            }
+                        });
+                    }
+                }
+            },
+
+            JSXOpeningElement(path) {
+                const nameNode = path.node.name;
+debugger;
+                if (nameNode.type === "JSXIdentifier" &&
+                        nameNode.name === "FormattedMessage") {
+                    const parent = path.findParent(ancestor => {
+                        return (ancestor.node.type === "JSXOpeningElement" &&
+                                ancestor.node.name?.name === "FormattedMessage");
+                    });
+                    if (parent) {
+                        results.push({
+                            pathName: ir.filePath,
+                            severity: "error",
+                            description: `Found a FormattedMessage component inside of another FormattedMessage component. This indicates a broken string.`,
+                            id: undefined,
+                            lineNumber: path.node.loc.start.line,
+                            charNumber: path.node.loc.start.column,
+                            endLineNumber: path.node.loc.end.line,
+                            endCharNumber: path.node.loc.end.column,
+                            // @TODO make a real highlight once IR contains raw content of the linted source file
+                            highlight: `<e0>${generate(path.node).code}</e0>`
+                        });
+                    }
+                }
+            }
+        });
+
+        return results.map(result => new Result({...result, rule: this}));
+    }
+}
+
+export default NoNestedMessages;

--- a/src/rules/NoNestedMessages.js
+++ b/src/rules/NoNestedMessages.js
@@ -84,7 +84,6 @@ class NoNestedMessages extends Rule {
 
             JSXOpeningElement(path) {
                 const nameNode = path.node.name;
-debugger;
                 if (nameNode.type === "JSXIdentifier" &&
                         nameNode.name === "FormattedMessage") {
                     const parent = path.findParent(ancestor => {

--- a/test/ReactPlugin.test.js
+++ b/test/ReactPlugin.test.js
@@ -47,7 +47,7 @@ describe("testReactPlugin", () => {
 
         const rules = jp.getRules();
         expect(rules).toBeTruthy();
-        expect(rules.length).toBe(2);
+        expect(rules.length).toBe(3);
     });
 
     test("ReactPluginGetFormatters", () => {
@@ -70,6 +70,6 @@ describe("testReactPlugin", () => {
         const sets = jp.getRuleSets();
 
         expect(sets.react).toBeTruthy();
-        expect(Object.keys(sets.react).length).toBe(2);
+        expect(Object.keys(sets.react).length).toBe(3);
     });
 });

--- a/test/rules/NoNestedMessages.test.js
+++ b/test/rules/NoNestedMessages.test.js
@@ -35,7 +35,7 @@ describe("No Nested FormattedMessage components rule", () => {
             return ir;
         };
 
-        test("hard coded string in Flow JSX", () => {
+        test("Nested FormattedMessage inside of another", () => {
             const ir = getFlowJsxIr(
                 "x/y.js",
                 `
@@ -90,5 +90,172 @@ describe("No Nested FormattedMessage components rule", () => {
 
             expect(result).toStrictEqual(expected);
         });
+
+        test("Nested FormattedMessage inside of another, using ids instead of the string directly in the code", () => {
+            const ir = getFlowJsxIr(
+                "x/y.js",
+                `
+                // @flow
+                import * as React from "react";
+                import { Button, Link, FormattedCompMessage } from "components";
+                import messages from './messages.js';
+
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return (
+                            <>
+                                <FormattedMessage {...messages.unique_id} 
+                                    values={{
+                                        termsAndConditions:
+                                            <a href="terms.html">
+                                                <FormattedMessage {...messages.terms.and.conditions} />
+                                            </a>
+                                    }}
+                                />
+                            </>
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoNestedMessages();
+
+            const result = rule.match({ ir });
+
+            const expected = [
+                new Result({
+                    severity: "error",
+                    description:
+                        "Found a FormattedMessage component inside of another FormattedMessage component. This indicates a broken string.",
+                    pathName: "x/y.js",
+                    rule,
+                    highlight: `<e0><FormattedMessage {...messages.terms.and.conditions} /></e0>`,
+                    lineNumber: 15,
+                    charNumber: 32,
+                    endLineNumber: 15,
+                    endCharNumber: 87,
+                })
+            ];
+
+            expect(result).toStrictEqual(expected);
+        });
+
+        test("No nested FormattedMessage inside of another", () => {
+            // this is the recommended rich text way of doing it
+            const ir = getFlowJsxIr(
+                "x/y.js",
+                `
+                // @flow
+                import * as React from "react";
+                import { Button, Link, FormattedCompMessage } from "components";
+
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return (
+                            <>
+                                <FormattedMessage
+                                    id="unique.id"
+                                    defaultMessage="You agree to the <a>terms and conditions</a> by using this product."
+                                    description="translator's note"
+                                    values={{
+                                        termsAndConditions: chunks => <a href="terms.html">{...chunks}</a>
+                                    }}
+                                />
+                            </>
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoNestedMessages();
+
+            const result = rule.match({ ir });
+
+            expect(result.length).toEqual(0);
+        });
+
+        test("No FormattedMessage at all", () => {
+            const ir = getFlowJsxIr(
+                "x/y.js",
+                `
+                // @flow
+                import * as React from "react";
+                import { Button, Link, FormattedCompMessage } from "components";
+
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return (
+                            <>
+                                <span>You agree to the <a href="terms.html">terms and conditions</a> by using this product.</span>
+                            </>
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoNestedMessages();
+
+            const result = rule.match({ ir });
+
+            expect(result.length).toEqual(0);
+        });
+
+        test("Nested intl.formatMessage inside of a FormattedMessage", () => {
+            const ir = getFlowJsxIr(
+                "x/y.js",
+                `
+                // @flow
+                import * as React from "react";
+                import { Button, Link, FormattedCompMessage } from "components";
+                import messages from './messages.js';
+
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return (
+                            <>
+                                <FormattedMessage
+                                    id="unique.id"
+                                    defaultMessage="You agree to the {termsAndConditions} by using this product."
+                                    description="translator's note"
+                                    values={{
+                                        termsAndConditions:
+                                            <a href="terms.html">
+                                                {intl.formatMessage(messages.unique_id)}
+                                            </a>
+                                    }}
+                                />
+                            </>
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoNestedMessages();
+
+            const result = rule.match({ ir });
+
+            const expected = [
+                new Result({
+                    severity: "error",
+                    description:
+                        "Found a call to intl.formatMessage() inside of a FormattedMessage component. This indicates a broken string.",
+                    pathName: "x/y.js",
+                    rule,
+                    highlight: `<e0>intl.formatMessage(messages.unique_id)</e0>`,
+                    lineNumber: 18,
+                    charNumber: 33,
+                    endLineNumber: 18,
+                    endCharNumber: 71,
+                })
+            ];
+
+            expect(result).toStrictEqual(expected);
+        });
+
     });
+
 });

--- a/test/rules/NoNestedMessages.test.js
+++ b/test/rules/NoNestedMessages.test.js
@@ -1,0 +1,94 @@
+/*
+ * NoNestedMessages.test.js
+ *
+ * Copyright © 2023 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Result } from "i18nlint-common";
+import FlowParser from "../../src/parsers/FlowParser.js";
+import JSXParser from "../../src/parsers/JSXParser.js";
+import NoNestedMessages from "../../src/rules/NoNestedMessages.js";
+import { trimIndent } from "../utils.js";
+
+/** @typedef {import("i18nlint-common").IntermediateRepresentation} IntermediateRepresentation */
+
+describe("No Nested FormattedMessage components rule", () => {
+    describe("Flow JSX", () => {
+        const getFlowJsxIr = (filePath, content) => {
+            const parser = new FlowParser();
+            parser.data = trimIndent(content);
+            parser.path = filePath;
+            const [ir] = parser.parse();
+            return ir;
+        };
+
+        test("hard coded string in Flow JSX", () => {
+            const ir = getFlowJsxIr(
+                "x/y.js",
+                `
+                // @flow
+                import * as React from "react";
+                import { Button, Link, FormattedCompMessage } from "components";
+
+                export class CustomComponent extends React.Component {
+                    render() {
+                        return (
+                            <>
+                                <FormattedMessage
+                                    id="unique.id"
+                                    defaultMessage="You agree to the {termsAndConditions} by using this product."
+                                    description="translator's note"
+                                    values={{
+                                        termsAndConditions:
+                                            <a href="terms.html">
+                                                <FormattedMessage
+                                                    id="another.id"
+                                                    defaultMessage="terms and conditions"
+                                                    description="terms and conditions"
+                                                />
+                                            </a>
+                                    }}
+                                />
+                            </>
+                        );
+                    }
+                }
+                `
+            );
+
+            const rule = new NoNestedMessages();
+
+            const result = rule.match({ ir });
+
+            const expected = [
+                new Result({
+                    severity: "error",
+                    description:
+                        "Found a FormattedMessage component inside of another FormattedMessage component. This indicates a broken string.",
+                    pathName: "x/y.js",
+                    rule,
+                    highlight: `<e0><FormattedMessage id="another.id" defaultMessage="terms and conditions" description="terms and conditions" /></e0>`,
+                    lineNumber: 17,
+                    charNumber: 32,
+                    endLineNumber: 21,
+                    endCharNumber: 34,
+                })
+            ];
+
+            expect(result).toStrictEqual(expected);
+        });
+    });
+});


### PR DESCRIPTION
I had 3 hours while riding in the car to the Christmas celebrations, so I decided to tackle a simple rule.

- if a FormattedMessage component exists inside of another FormattedMessage component, give an error because it means a composed/broken string
- also applies to calls to intl.formatMessage inside of a FormattedMessage component